### PR TITLE
Instantiate components in Awake to make Unity happy

### DIFF
--- a/2_Core/Replayer/Emulation/Scoring/ReplayerScoreProcessor.cs
+++ b/2_Core/Replayer/Emulation/Scoring/ReplayerScoreProcessor.cs
@@ -19,7 +19,11 @@ namespace BeatLeader.Replayer.Emulation {
 
         #region Setup
 
+        private NoteControllerEmulator _noteControllerEmulator;
+
         private void Awake() {
+            _noteControllerEmulator = new GameObject(nameof(NoteControllerEmulator)).AddComponent<NoteControllerEmulator>();
+
             _eventsProcessor.NoteProcessRequestedEvent += HandleNoteProcessRequested;
             _eventsProcessor.WallProcessRequestedEvent += HandleWallProcessRequested;
             _eventsProcessor.ReprocessRequestedEvent += HandleReprocessRequested;
@@ -39,9 +43,6 @@ namespace BeatLeader.Replayer.Emulation {
         #endregion
 
         #region Logic
-
-        private readonly NoteControllerEmulator _noteControllerEmulator =
-            new GameObject("NoteControllerEmulator").AddComponent<NoteControllerEmulator>();
 
         private static bool _lastCutIsGood;
         private static float _lastCutBeforeCutRating;


### PR DESCRIPTION
This should fix #58, which was a valid but ignored issue. Unity debug builds force devs to make use of good practices, and turning the game into a debug build is required if you want to profile it.

I didn't go more in-depth into fixing this kind of issue so there's maybe some left, but that fixes UI and replays.