### PR TITLE
Add score to replay filenames

### DIFF
--- a/Source/7_Utils/FileManager.cs
+++ b/Source/7_Utils/FileManager.cs
@@ -62,7 +62,7 @@ namespace BeatLeader.Utils
         {
             string practice = replay.info.speed != 0 ? "-practice" : "";
             string fail = replay.info.failTime != 0 ? "-fail" : "";
-            string filename = $"{replay.info.playerID}{practice}{fail}-{replay.info.songName}-{replay.info.difficulty}-{replay.info.mode}-{replay.info.hash}.bsor";
+            string filename = $"{replay.info.playerID}{practice}{fail}-{replay.info.songName}-{replay.info.difficulty}-{replay.info.mode}-{replay.info.score}-{replay.info.hash}.bsor";
             string regexSearch = new string(Path.GetInvalidFileNameChars()) + new string(Path.GetInvalidPathChars());
             Regex r = new (string.Format("[{0}]", Regex.Escape(regexSearch)));
             return folder + r.Replace(filename, "_");


### PR DESCRIPTION
Adds the score to the filename of a replay, so incremental replays can be saved to look back and compare for improvements.

One possible concern is that people could easily fill their disk with replays if they don't know they're being saved for each run of a song rather than just 1 replay being saved. Maybe it should be locked behind a config option?