### PR TITLE
Only show pause icons if paused between first and last note

### DIFF
--- a/Source/8_UI/Replayer/Components/Toolbar/Timeline.cs
+++ b/Source/8_UI/Replayer/Components/Toolbar/Timeline.cs
@@ -153,6 +153,9 @@ namespace BeatLeader.Components {
         }
 
         private void GenerateDefaultMarkersFromReplay(IReplay replay) {
+            float firstNoteTime = replay.NoteEvents.First().eventTime;
+            float lastNoteTime = replay.NoteEvents.Last().eventTime;
+
             GenerateMarkers(replay.NoteEvents
                 .Where(x => x.eventType is NoteEvent.NoteEventType.Miss
                     or NoteEvent.NoteEventType.BadCut)
@@ -163,6 +166,7 @@ namespace BeatLeader.Components {
                 .Select(x => x.eventTime), _bombPrefab.gameObject);
 
             GenerateMarkers(replay.PauseEvents
+                .Where(x => x.time >= firstNoteTime && x.time <= lastNoteTime)
                 .Select(x => x.time), _pausePrefab.gameObject);
         }
 

--- a/Source/8_UI/Replayer/Components/Toolbar/Timeline.cs
+++ b/Source/8_UI/Replayer/Components/Toolbar/Timeline.cs
@@ -153,8 +153,8 @@ namespace BeatLeader.Components {
         }
 
         private void GenerateDefaultMarkersFromReplay(IReplay replay) {
-            float firstNoteTime = replay.NoteEvents.First().eventTime;
-            float lastNoteTime = replay.NoteEvents.Last().eventTime;
+            float firstNoteTime = replay.NoteEvents.FirstOrDefault().eventTime;
+            float lastNoteTime = replay.NoteEvents.LastOrDefault().eventTime;
 
             GenerateMarkers(replay.NoteEvents
                 .Where(x => x.eventType is NoteEvent.NoteEventType.Miss


### PR DESCRIPTION
This will match the web replay UI's behaviour and remove pauses caused by mods that pause the game at song start or song end.