### PR TITLE
Make ReplayDecoder public

### DIFF
--- a/Source/2_Core/Models/Replay.cs
+++ b/Source/2_Core/Models/Replay.cs
@@ -513,7 +513,7 @@ namespace BeatLeader.Models.Replay {
             stream.Write(quaternion.w);
         }
     }
-    static class ReplayDecoder
+    public static class ReplayDecoder
     {
         public static bool TryDecodeReplayInfo(byte[] buffer, out ReplayInfo? info) {
             try {


### PR DESCRIPTION
Makes ReplayDecoder public so I am able to use it in LocalLeaderboard without reflection