### PR TITLE
Update CustomNotes Plugin ID

### DIFF
--- a/Source/7_Utils/Interop/CustomNotesInterop.cs
+++ b/Source/7_Utils/Interop/CustomNotesInterop.cs
@@ -4,7 +4,7 @@ using System;
 using System.Reflection;
 
 namespace BeatLeader.Interop {
-    [PluginInterop("Custom Notes")]
+    [PluginInterop("CustomNotes")]
     internal static class CustomNotesInterop {
         #region Init
 

--- a/Source/manifest.json
+++ b/Source/manifest.json
@@ -21,7 +21,7 @@
     "BeatSaviorData",
     "NoodleExtensions",
     "ScoreSaber",
-    "Custom Notes"
+    "CustomNotes"
   ],
   "features": []
 }


### PR DESCRIPTION
i'm sorry that i didn't think about this sooner, but custom notes' plugin id is now `CustomNotes`