### PR TITLE
Update CustomNotes names for CustomNotes 2.6.9+

### DIFF
--- a/Source/7_Utils/Interop/CustomNotesInterop.cs
+++ b/Source/7_Utils/Interop/CustomNotesInterop.cs
@@ -8,13 +8,13 @@ namespace BeatLeader.Interop {
     internal static class CustomNotesInterop {
         #region Init
 
-        [PluginType("CustomNotes.Managers.CustomNoteController")]
+        [PluginType("CustomNotes.Components.CustomNoteController")]
         private static readonly Type _customNoteControllerType;
 
-        [PluginType("CustomNotes.Managers.CustomBombController")]
+        [PluginType("CustomNotes.Components.CustomBombController")]
         private static readonly Type _customBombControllerType;
 
-        [PluginType("CustomNotes.Managers.CustomBurstSliderController")]
+        [PluginType("CustomNotes.Components.CustomBurstSliderController")]
         private static readonly Type _customSliderControllerType;
 
         [PluginState]
@@ -34,7 +34,7 @@ namespace BeatLeader.Interop {
             _finishBombControllerMethod = _customBombControllerType
                 .GetMethod("DidFinish", ReflectionUtils.DefaultFlags);
             _bombControllerContainerField = _customBombControllerType
-                .GetField("container", ReflectionUtils.DefaultFlags);
+                .GetField("siraContainer", ReflectionUtils.DefaultFlags);
         }
 
         #endregion

--- a/Source/7_Utils/Interop/SongCoreInterop.cs
+++ b/Source/7_Utils/Interop/SongCoreInterop.cs
@@ -5,11 +5,11 @@ namespace BeatLeader.Interop {
     internal static class SongCoreInterop {
 
         #region TryGetBeatmapRequirements
-        
+
         public static bool TryGetBeatmapRequirements(BeatmapLevel beatmap, BeatmapKey key, out string[]? requirements) {
             requirements = null;
             try {
-                var data = SongCore.Collections.GetCustomLevelSongDifficultyData(key);
+                var data = SongCore.Collections.RetrieveDifficultyData(beatmap, key);
                 if (data == null) return false;
                 var reqData = data.additionalDifficultyData;
                 if (reqData == null) return false;

--- a/Source/7_Utils/Interop/SongCoreInterop.cs
+++ b/Source/7_Utils/Interop/SongCoreInterop.cs
@@ -5,11 +5,11 @@ namespace BeatLeader.Interop {
     internal static class SongCoreInterop {
 
         #region TryGetBeatmapRequirements
-
+        
         public static bool TryGetBeatmapRequirements(BeatmapLevel beatmap, BeatmapKey key, out string[]? requirements) {
             requirements = null;
             try {
-                var data = SongCore.Collections.RetrieveDifficultyData(beatmap, key);
+                var data = SongCore.Collections.GetCustomLevelSongDifficultyData(key);
                 if (data == null) return false;
                 var reqData = data.additionalDifficultyData;
                 if (reqData == null) return false;


### PR DESCRIPTION
not sure what this does but i've reorganized CustomNotes completely so i'm updating these namespaces to be correct for the new version, which is what will be uploaded on BS 1.40.0

side note, in replays, i'm experiencing custom note bombs getting despawned (or reparented?) so that only up to 3 bomb models are visible at any time