### PR TITLE
Correct dependency names in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,5 +17,5 @@ If you experience any issues, have any suggestions or bug reports - you can leav
 
 ## Dependencies
 
-- BSIPA, BSML, SiraUtil - available in [ModAssistant](https://github.com/Assistant/ModAssistant/releases/latest) and on the [BeatMods website](https://beatmods.com/#/mods)
+- BSIPA, BeatSaberMarkupLanguage, SiraUtil - available in [ModAssistant](https://github.com/Assistant/ModAssistant/releases/latest) and on the [BeatMods website](https://beatmods.com/#/mods)
 - [LeaderboardCore](https://github.com/rithik-b/LeaderboardCore)


### PR DESCRIPTION
spent a while trying to figure out what "BSML" meant before i figured out I already had it downloaded... it's not abbreviated in many other places, so this feels like a helpful change.