### PR TITLE
Fixed retries, timeout from waiting on login and status messages for requests

### DIFF
--- a/Source/2_Core/APIV2/Methods/AuthRequest.cs
+++ b/Source/2_Core/APIV2/Methods/AuthRequest.cs
@@ -10,15 +10,16 @@ namespace BeatLeader.APIV2 {
             string authToken,
             string provider
         ) {
-            var formContent = new FormUrlEncodedContent(new[]
-            {
-                new KeyValuePair<string, string>("ticket", authToken),
-                new KeyValuePair<string, string>("provider", provider),
-                new KeyValuePair<string, string>("returnUrl", "/")
-            });
-            return Send(BLConstants.SIGNIN_WITH_TICKET, HttpMethod.Post, formContent, new WebRequestParams {
-                RetryCount = 3
-            }, waitForLogin: false);
+            return Send(BLConstants.SIGNIN_WITH_TICKET, HttpMethod.Post,
+                () => new FormUrlEncodedContent(new[]
+                {
+                    new KeyValuePair<string, string>("ticket", authToken),
+                    new KeyValuePair<string, string>("provider", provider),
+                    new KeyValuePair<string, string>("returnUrl", "/")
+                }),
+                new WebRequestParams {
+                    RetryCount = 3
+                }, waitForLogin: false);
         }
     }
 }

--- a/Source/2_Core/APIV2/Methods/GetOculusUserRequest.cs
+++ b/Source/2_Core/APIV2/Methods/GetOculusUserRequest.cs
@@ -19,11 +19,11 @@ namespace BeatLeader.APIV2 {
                 return;
             }
 
-            var formContent = new FormUrlEncodedContent(new[]
-            {
-                new KeyValuePair<string, string>("token", authToken)
-            });
-            SendRet(Endpoint, HttpMethod.Post, formContent);
+            SendRet(Endpoint, HttpMethod.Post,
+                () => new FormUrlEncodedContent(new[]
+                {
+                    new KeyValuePair<string, string>("token", authToken)
+                }));
         }
     }
 }

--- a/Source/2_Core/APIV2/Methods/LatestReleasesRequest.cs
+++ b/Source/2_Core/APIV2/Methods/LatestReleasesRequest.cs
@@ -9,7 +9,7 @@ namespace BeatLeader.APIV2 {
         private static string Endpoint => BLConstants.BEATLEADER_API_URL + "/mod/lastVersions";
 
         public static void Send() {
-            SendRet(Endpoint, HttpMethod.Get);
+            SendRet(Endpoint, HttpMethod.Get, waitForLogin: false);
         }
     }
 }

--- a/Source/2_Core/APIV2/Methods/UpdateAvatarRequest.cs
+++ b/Source/2_Core/APIV2/Methods/UpdateAvatarRequest.cs
@@ -9,8 +9,8 @@ namespace BeatLeader.APIV2 {
     internal class UpdateAvatarRequest : PersistentWebRequestBase {
         public static IWebRequest<object> Send(string playerId, AvatarSettings avatarSettings) {
             var body = JsonConvert.SerializeObject(avatarSettings);
-            var content = new StringContent(body, Encoding.UTF8, "application/json");
-            return Send($"{BLConstants.BEATLEADER_API_URL}/player/{playerId}/ingameavatar", HttpMethod.Post, content);
+            return Send($"{BLConstants.BEATLEADER_API_URL}/player/{playerId}/ingameavatar", HttpMethod.Post,
+                () => new StringContent(body, Encoding.UTF8, "application/json"));
         }
     }
 }

--- a/Source/2_Core/APIV2/Methods/UploadReplayRequest.cs
+++ b/Source/2_Core/APIV2/Methods/UploadReplayRequest.cs
@@ -22,10 +22,13 @@ namespace BeatLeader.APIV2 {
                 var url = string.Format(WithCookieEndpoint, NetworkingUtils.ToHttpParams(query));
 
                 var compressedData = CompressReplay(replay);
-                var content = new ByteArrayContent(compressedData);
-                content.Headers.ContentEncoding.Add("gzip");
 
-                SendRet(url, HttpMethod.Put, content,
+                SendRet(url, HttpMethod.Put,
+                    () => {
+                        var content = new ByteArrayContent(compressedData);
+                        content.Headers.ContentEncoding.Add("gzip");
+                        return content;
+                    },
                     new WebRequestParams {
                         RetryCount = 3,
                         TimeoutSeconds = 120

--- a/Source/2_Core/APIV2/PersistentWebRequest.cs
+++ b/Source/2_Core/APIV2/PersistentWebRequest.cs
@@ -15,14 +15,16 @@ namespace BeatLeader.WebRequests {
         protected static IWebRequest<object> Send(
             string url,
             HttpMethod method,
-            HttpContent? content = null,
+            Func<HttpContent?>? contentFactory = null,
             WebRequestParams? requestParams = null,
             Action<HttpRequestHeaders>? headersCallback = null,
             CancellationToken token = default,
             bool waitForLogin = true
         ) {
-            var requestMessage = CreateAndValidateRequestMessage(url, method, content, headersCallback);
-            return WebRequestFactory.Send(requestMessage, requestParams, token, waitForLogin);
+            return WebRequestFactory.Send(
+                () => CreateAndValidateRequestMessage(url, method, contentFactory?.Invoke(), headersCallback),
+                requestParams, token, waitForLogin
+            );
         }
 
         protected static HttpRequestMessage CreateAndValidateRequestMessage(
@@ -48,14 +50,16 @@ namespace BeatLeader.WebRequests {
         protected static IWebRequest<TResult> SendRet(
             string url,
             HttpMethod method,
-            HttpContent? content = null,
+            Func<HttpContent?>? contentFactory = null,
             WebRequestParams? requestParams = null,
             Action<HttpRequestHeaders>? headersCallback = null,
             CancellationToken token = default,
             bool waitForLogin = true
         ) {
-            var requestMessage = CreateAndValidateRequestMessage(url, method, content, headersCallback);
-            return WebRequestFactory.Send(requestMessage, descriptor, requestParams, token, waitForLogin);
+            return WebRequestFactory.Send(
+                () => CreateAndValidateRequestMessage(url, method, contentFactory?.Invoke(), headersCallback),
+                descriptor, requestParams, token, waitForLogin
+            );
         }
     }
 
@@ -71,14 +75,12 @@ namespace BeatLeader.WebRequests {
         protected static void SendRet(
             string url,
             HttpMethod method,
-            HttpContent? content = null,
+            Func<HttpContent?>? contentFactory = null,
             WebRequestParams? requestParams = null,
             Action<HttpRequestHeaders>? headersCallback = null,
             TDescriptor? customParser = default,
             bool waitForLogin = true
         ) {
-            var requestMessage = CreateAndValidateRequestMessage(url, method, content, headersCallback);
-
             if (Instance != null) {
                 tokenSource.Cancel();
                 tokenSource.Dispose();
@@ -89,7 +91,9 @@ namespace BeatLeader.WebRequests {
             }
 
             Task.Run(async () => {
-                    Instance = WebRequestFactory.Send(requestMessage, customParser ?? descriptor, requestParams, tokenSource.Token, waitForLogin);
+                    Instance = WebRequestFactory.Send(
+                        () => CreateAndValidateRequestMessage(url, method, contentFactory?.Invoke(), headersCallback),
+                        customParser ?? descriptor, requestParams, tokenSource.Token, waitForLogin);
                     Instance.StateChangedEvent += Instance_StateChangedEvent;
                     Instance.ProgressChangedEvent += Instance_ProgressChangedEvent;
                     Instance_StateChangedEvent(Instance, RequestState, FailReason);

--- a/Source/2_Core/APIV2/WebRequestFactory.cs
+++ b/Source/2_Core/APIV2/WebRequestFactory.cs
@@ -19,32 +19,30 @@ namespace BeatLeader.WebRequests {
         }
 
         public static IWebRequest<object> Send(
-                HttpRequestMessage requestMessage,
+                Func<HttpRequestMessage> requestMessageFactory,
                 WebRequestParams? requestParams = null,
                 CancellationToken token = default,
                 bool waitForLogin = true
             ) {
             requestParams ??= new();
-            SendRequestDelegate sendCallback = waitForLogin
-                ? (message, requestToken) => SendInternalLogin(message, requestParams.ResponseCompletionOption, requestToken)
-                : (message, requestToken) => SendInternal(message, requestParams.ResponseCompletionOption, requestToken);
+            PreSendRequestDelegate? preSendCallback = waitForLogin ? (requestToken) => WaitLogin(requestToken) : null;
+            SendRequestDelegate sendCallback = (message, requestToken) => SendInternal(message, requestParams.ResponseCompletionOption, requestToken);
 
-            return new WebRequestProcessor<object>(sendCallback, requestMessage, requestParams, null, token);
+            return new WebRequestProcessor<object>(preSendCallback, sendCallback, requestMessageFactory, requestParams, null, token);
         }
 
         public static IWebRequest<T> Send<T>(
-            HttpRequestMessage requestMessage,
+            Func<HttpRequestMessage> requestMessageFactory,
             IWebRequestResponseParser<T> responseParser,
             WebRequestParams? requestParams = null,
             CancellationToken token = default,
             bool waitForLogin = true
         ) {
             requestParams ??= new();
-            SendRequestDelegate sendCallback = waitForLogin
-                ? (message, requestToken) => SendInternalLogin(message, requestParams.ResponseCompletionOption, requestToken)
-                : (message, requestToken) => SendInternal(message, requestParams.ResponseCompletionOption, requestToken);
+            PreSendRequestDelegate? preSendCallback = waitForLogin ? (requestToken) => WaitLogin(requestToken) : null;
+            SendRequestDelegate sendCallback = (message, requestToken) => SendInternal(message, requestParams.ResponseCompletionOption, requestToken);
 
-            return new WebRequestProcessor<T>(sendCallback, requestMessage, requestParams, responseParser, token);
+            return new WebRequestProcessor<T>(preSendCallback, sendCallback, requestMessageFactory, requestParams, responseParser, token);
         }
 
         private static Task<HttpResponseMessage?> SendInternal(
@@ -56,17 +54,9 @@ namespace BeatLeader.WebRequests {
             return httpClient.SendAsync(requestMessage, completionOption, token);
         }
 
-        private static Task<HttpResponseMessage?> SendInternalLogin(
-            HttpRequestMessage requestMessage,
-            HttpCompletionOption completionOption,
-            CancellationToken token
-        ) {
-            ApplyDefaultHeaders(requestMessage);
-
+        private static Task<bool> WaitLogin(CancellationToken token) {
             return Task.Run(async () => {
-                var loggedIn = await Authentication.WaitLogin();
-                if (!loggedIn) return null;
-                return await httpClient.SendAsync(requestMessage, completionOption, token);
+                return await Authentication.WaitLogin();
             }).RunCatching();
         }
 

--- a/Source/2_Core/APIV2/WebRequestProcessor.cs
+++ b/Source/2_Core/APIV2/WebRequestProcessor.cs
@@ -12,26 +12,29 @@ using BeatLeader.Models;
 using BeatLeader.Utils;
 
 namespace BeatLeader.WebRequests {
+    internal delegate Task<bool> PreSendRequestDelegate(CancellationToken token);
     internal delegate Task<HttpResponseMessage?> SendRequestDelegate(HttpRequestMessage request, CancellationToken token);
 
     internal class WebRequestProcessor<T> : IWebRequest<T>, IIoOperationDescriptor, IDisposable {
         public WebRequestProcessor(
+            PreSendRequestDelegate? preSendCallback,
             SendRequestDelegate sendCallback,
-            HttpRequestMessage requestMessage,
+            Func<HttpRequestMessage> requestMessageFactory,
             WebRequestParams requestParams,
             IWebRequestResponseParser<T>? requestResponseParser,
             CancellationToken token
         ) {
-            ValidateHttpMessage(requestMessage);
+            _preSendCallback = preSendCallback;
             _sendCallback = sendCallback;
-            _requestMessage = requestMessage;
+            _requestMessageFactory = requestMessageFactory;
             RequestParams = requestParams;
             _requestResponseParser = requestResponseParser;
 
             _cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(token);
             _cancellationToken = _cancellationTokenSource.Token;
 
-            _requestTask = SendWebRequest(sendCallback, _cancellationToken);
+            _requestMessage = CreateRequestMessage();
+            _requestTask = SendWebRequest(preSendCallback, sendCallback, _cancellationToken);
             _processTask = ProcessWebRequest(_cancellationToken);
         }
 
@@ -98,6 +101,12 @@ namespace BeatLeader.WebRequests {
         
 
         #region Validation
+
+        private HttpRequestMessage CreateRequestMessage() {
+            var requestMessage = _requestMessageFactory();
+            ValidateHttpMessage(requestMessage);
+            return requestMessage;
+        }
 
         private void ValidateHttpMessage(HttpRequestMessage requestMessage) {
             var content = requestMessage.Content;
@@ -188,7 +197,13 @@ namespace BeatLeader.WebRequests {
 
         #region SendWebRequest
 
-        private async Task<HttpResponseMessage?> SendWebRequest(SendRequestDelegate sendCallback, CancellationToken token) {
+        private async Task<HttpResponseMessage?> SendWebRequest(PreSendRequestDelegate? preSendCallback, SendRequestDelegate sendCallback, CancellationToken token) {
+            if (preSendCallback != null) {
+                if (!(await preSendCallback(token))) {
+                    throw new TaskCanceledException($"Request pre-send action failed");
+                }
+            }
+
             var timeout = RequestParams.TimeoutSeconds;
             using var timeoutTokenSource = GetTimeoutTokenSource(TimeSpan.FromSeconds(timeout), token);
             var linkedToken = timeoutTokenSource?.Token ?? token;
@@ -218,7 +233,9 @@ namespace BeatLeader.WebRequests {
         protected WebRequestParams RequestParams { get; }
 
         private Task<HttpResponseMessage?> _requestTask;
-        private readonly HttpRequestMessage _requestMessage;
+        private HttpRequestMessage _requestMessage;
+        private readonly Func<HttpRequestMessage> _requestMessageFactory;
+        private readonly PreSendRequestDelegate? _preSendCallback;
         private readonly SendRequestDelegate _sendCallback;
         private readonly Task _processTask;
         
@@ -264,23 +281,27 @@ namespace BeatLeader.WebRequests {
 
         private async Task ProcessFailure(HttpResponseMessage? httpResponse, Exception? ex) {
             if (ex != null) {
-                RequestState = RequestState.Failed;
                 if (ex is TaskCanceledException) {
                     FailReason = "Request cancelled";
                     Plugin.Log.Debug($"[Request({_requestTask.GetHashCode()})] Cancelled");
+                } else if (RetryAttempt < RequestParams.RetryCount) {
+                    await Retry();
+                } else if (ex is TimeoutException) {
+                    FailReason = "Request timed out";
+                    Plugin.Log.Debug($"[Request({_requestTask.GetHashCode()})] Timed out");
                 } else {
                     FailReason = "Exception occured, please report on Discord";
                     Plugin.Log.Info($"[Request({_requestTask.GetHashCode()})] Exception: {ex}");
                 }
+                RequestState = RequestState.Failed;
             } else if (httpResponse != null) {
                 NetworkingUtils.GetRequestFailReason(httpResponse, out string failReason, out bool shouldRetry);
+                FailReason = failReason;
+                RequestState = RequestState.Failed;
 
                 if (shouldRetry && RetryAttempt < RequestParams.RetryCount) {
                     await Retry();
-                    return;
                 } else {
-                    RequestState = RequestState.Failed;
-                    FailReason = failReason;
                     Plugin.Log.Info($"[Request({_requestTask.GetHashCode()})] Fail reason: {failReason}");
                 }
             }
@@ -289,7 +310,11 @@ namespace BeatLeader.WebRequests {
         private async Task Retry() {
             RetryAttempt++;
 
-            _requestTask = SendWebRequest(_sendCallback, _cancellationToken);
+            Plugin.Log.Info($"[Request({_requestTask.GetHashCode()})] Retrying: {RetryAttempt}");
+
+            _requestMessage.Dispose();
+            _requestMessage = CreateRequestMessage();
+            _requestTask = SendWebRequest(_preSendCallback, _sendCallback, _cancellationToken);
             await ProcessWebRequest(_cancellationToken);
         }
 

--- a/Source/8_UI/Leaderboard/Components/TopPanel/StatusBar.cs
+++ b/Source/8_UI/Leaderboard/Components/TopPanel/StatusBar.cs
@@ -28,6 +28,7 @@ namespace BeatLeader.Components {
         }
 
         private void OnDisable() {
+            if (!_animating) return;
             StopAllCoroutines();
             MessageText = "";
         }
@@ -87,28 +88,33 @@ namespace BeatLeader.Components {
 
         #region ShowMessage
 
-        private const float DefaultDuration = 1.4f;
         private const string GoodNewsColor = "#88FF88";
         private const string BadNewsColor = "#FF8888";
+        private bool _animating = false;
 
-        private void ShowGoodNews(string message, float duration = DefaultDuration) {
+        private void ShowGoodNews(string message, float duration = 20f) {
             ShowMessage($"<color={GoodNewsColor}>{message}", duration);
         }
 
-        private void ShowBadNews(string message, float duration = DefaultDuration) {
+        private void ShowBadNews(string message, float duration = 60f) {
             ShowMessage($"<color={BadNewsColor}>{message}", duration);
         }
 
-        private void ShowMessage(string message, float duration = DefaultDuration) {
-            if (!gameObject.activeInHierarchy) return;
+        private void ShowMessage(string message, float duration) {
+            if (!gameObject.activeInHierarchy) {
+                MessageText = message;
+                return;
+            }
             StopAllCoroutines();
             StartCoroutine(ShowMessageCoroutine(message, duration));
         }
 
         private IEnumerator ShowMessageCoroutine(string message, float duration) {
             MessageText = message;
+            _animating = true;
             yield return new WaitForSeconds(duration);
             MessageText = "";
+            _animating = false;
         }
 
         #endregion


### PR DESCRIPTION
- Retries were failing because of the request message reusage
- Timeout included waiting for login, so early requests could timeout simply from a long task on the game load
- Setting `RequestState` before the `FailReason` broke status messages shown on top of the leaderboard
- ...but they were not visible anyway, especially after posting the score. Both because of the 1.4sec hide timer and because if the leaderboard was unloaded, the error message was simply discarded